### PR TITLE
fix: add missing schema fields for MCC class data persistence

### DIFF
--- a/module/mcc-classes.js
+++ b/module/mcc-classes.js
@@ -29,9 +29,25 @@ Hooks.on('dcc.definePlayerSchema', (schema) => {
     value: new StringField({ initial: '' })
   })
 
+  // MCC class-specific fields
+  schema.class.fields.manimalSubType = new SchemaField({
+    label: new StringField({ initial: 'MCC.ManimalSubType' }),
+    value: new StringField({ initial: '' })
+  })
+  schema.class.fields.plantientSubType = new SchemaField({
+    label: new StringField({ initial: 'MCC.PlantientSubType' }),
+    value: new StringField({ initial: '' })
+  })
+  schema.class.fields.mutantAppearance = new SchemaField({
+    label: new StringField({ initial: 'MCC.MutantAppearance' }),
+    value: new StringField({ initial: '' })
+  })
+  schema.class.fields.aiPatron = new SchemaField({
+    label: new StringField({ initial: 'Shaman.AIPatron' }),
+    value: new StringField({ initial: '' })
+  })
+
   // MCC custom skills - these use the same structure as DCC skills
-  // Skills are added dynamically in each class sheet, but defining the schema
-  // ensures proper validation and defaults
 
   // Shared MCC skills
   schema.skills.fields.aiRecognition = new SchemaField({
@@ -45,6 +61,24 @@ Hooks.on('dcc.definePlayerSchema', (schema) => {
   schema.skills.fields.maxTechLevel = new SchemaField({
     label: new StringField({ initial: 'MCC.MaxTechLevel' }),
     value: new StringField({ initial: '0' })
+  })
+
+  // Healer skills
+  schema.skills.fields.naturopathy = new SchemaField({
+    label: new StringField({ initial: 'Healer.Naturopathy' }),
+    value: new StringField({ initial: '' })
+  })
+
+  // Mutant skills
+  schema.skills.fields.mutantHorror = new SchemaField({
+    label: new StringField({ initial: 'Mutant.MutantHorror' }),
+    value: new StringField({ initial: '1d3' })
+  })
+
+  // Sentinel skills
+  schema.skills.fields.artifactDie = new SchemaField({
+    label: new StringField({ initial: 'Sentinel.ArtifactDie' }),
+    value: new StringField({ initial: '1d3' })
   })
 
   // Rover skills


### PR DESCRIPTION
## Summary
- Several MCC class-specific fields (manimalSubType, plantientSubType, mutantAppearance, aiPatron, mutantHorror, naturopathy, artifactDie) were used in sheet templates and `_prepareContext` but never defined in the `dcc.definePlayerSchema` hook
- Foundry V13's strict DataModel silently strips fields not in the schema, so all data entered in these fields was lost on save
- This caused the reported bug: Manimal/Plantient/Mutant class tabs always appeared blank after closing and reopening

## Test plan
- [ ] Open a Manimal sheet, enter data in Manimal Sub Type and other class fields, close and reopen - data should persist
- [ ] Open a Plantient sheet, enter data in Plantient Sub Type, close and reopen - data should persist
- [ ] Open a Mutant sheet, enter data in Mutant Appearance and Mutant Horror, close and reopen - data should persist
- [ ] Open a Healer sheet, verify Naturopathy field persists
- [ ] Open a Sentinel sheet, verify Artifact Die field persists
- [ ] Open a Shaman sheet, verify AI Patron field persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)